### PR TITLE
content-sha256

### DIFF
--- a/src/clj_aws_sign/core.clj
+++ b/src/clj_aws_sign/core.clj
@@ -150,6 +150,14 @@
         (.append k) (.append ":") (.append v) (.append "\n")))
     (.toString s)))
 
+(defn content-sha256
+  "Returns content sha256 given payload"
+  [payload]
+  (cond
+    (= payload UNSIGNED_PAYLOAD) UNSIGNED_PAYLOAD
+    (nil? payload) EMPTY_SHA256
+    :else (sha-256 (to-utf8 payload))))
+
 (defn canonical-request
   "Returns canonical request as string"
   [{:keys [method uri query payload headers]}]
@@ -160,10 +168,7 @@
    (stringify-headers headers)   \newline
    (str/join ";" (keys headers)) \newline
    (or (get headers "x-amz-content-sha256")
-       (when (= payload UNSIGNED_PAYLOAD)
-         UNSIGNED_PAYLOAD)
-       (sha-256 (to-utf8 payload))
-       EMPTY_SHA256)))
+       (content-sha256 payload))))
 
 ;; ---------- AWS authentication
 

--- a/test/clj_aws_sign/core_test.clj
+++ b/test/clj_aws_sign/core_test.clj
@@ -101,3 +101,27 @@
                                        :payload payload :region region :service service
                                        :access-key access-key-id :secret-key secret-key}))
            (str "returns valid authorization header for " name)))))))
+
+(deftest content-sha256
+  (testing "content-sha256"
+    (is
+     (= sut/EMPTY_SHA256 (sut/content-sha256 nil))
+     "returns empty sha256 for nil payload")
+
+    (is
+     (= sut/EMPTY_SHA256 (sut/content-sha256 ""))
+     "returns empty sha256 for empty payload")
+
+    (is
+     (= "36a9e7f1c95b82ffb99743e0c5c4ce95d83c9a430aac59f84ef3cbfab6145068"
+        (sut/content-sha256 " "))
+     "returns valid sha256 for space payload")
+
+    (is
+     (= "3b435d551623a7ac9499f66703d2eccb10299334bace5a9590982cdabd8c137f"
+       (sut/content-sha256 "{\"encoded payload\": \"value\"}"))
+     "returns valid sha256 for non-empty payload")
+
+    (is
+     (= sut/UNSIGNED_PAYLOAD (sut/content-sha256 sut/UNSIGNED_PAYLOAD))
+      "returns UNSIGNED_PAYLOAD for UNSIGNED_PAYLOAD")))


### PR DESCRIPTION
#4 - https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html

For our use-case, we would like to compute `x-amz-content-sha256` without calling `SHA_256` directly.